### PR TITLE
IG-039 Add Severity field to SastResultPrompt to enable sorting by severity

### DIFF
--- a/prompts/sast_result_remediation/build-prompt.go
+++ b/prompts/sast_result_remediation/build-prompt.go
@@ -8,6 +8,7 @@ type SastResultPrompt struct {
 	ResultsFile string
 	Language    string
 	Query       string
+	Severity    string
 	ResultId    string
 	SourcePath  string
 	System      string
@@ -82,6 +83,7 @@ func (pb *PromptBuilder) BuildPromptsForResultsList(resultsListFile string) []*S
 func (pb *PromptBuilder) BuildPromptFromResult(result *Result) *SastResultPrompt {
 	prompt := pb.initPrompt(result.Data.LanguageName, result.Data.QueryName)
 	prompt.ResultId = result.ID
+	prompt.Severity = result.Severity
 	sources, err := pb.GetSourcesForResult(result)
 	if err != nil {
 		prompt.Error = fmt.Errorf("error getting sources for result ID '%s': '%v'", result.ID, err)

--- a/prompts/sast_result_remediation/prompt.go
+++ b/prompts/sast_result_remediation/prompt.go
@@ -93,6 +93,7 @@ func (pb *PromptBuilder) CreatePromptsForResults(results []*Result, cleanSources
 			Language:    result.Data.LanguageName,
 			Query:       result.Data.QueryName,
 			ResultId:    result.ID,
+			Severity:    result.Severity,
 		}
 		prompt.System = GetSystemPrompt()
 		sources := copyCleanSources(cleanSources)


### PR DESCRIPTION
Severity is used to sort the generated prompt according to decreasing severity